### PR TITLE
Ignore code-related state changes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Ignore state changes pertaining to the code that the Lambda hosts

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "main" {
   tags = var.lambda_tags
 
   // These are likely to be mutually exclusive, which is the rationale for using all of them at once
-  // Unfortunately lifecycle config can't be parametrised, and consumers of the module might be using
+  // Unfortunately lifecycle config can't be parameterised, and consumers of the module might be using
   // any of these 3 methods of specifying the Lambda source
   lifecycle {
     ignore_changes = [

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,17 @@ resource "aws_lambda_function" "main" {
 
   tags = var.lambda_tags
 
+  // These are likely to be mutually exclusive, which is the rationale for using all of them at once
+  // Unfortunately lifecycle config can't be parametrised, and consumers of the module might be using
+  // any of these 3 methods of specifying the Lambda source
+  lifecycle {
+    ignore_changes = [
+      filename,
+      image_uri,
+      s3_object_version
+    ]
+  }
+
   // All parameters below are passed through directly
   architectures           = var.architectures
   code_signing_config_arn = var.code_signing_config_arn


### PR DESCRIPTION
Not 100% sure this is the right approach; an alternative would be providing entirely separate (ie largely duplicate) modules for different `lifecycle` variants as it is strictly impossible to parametrise resource lifecycle :( 